### PR TITLE
feat: 新增皮卡鱼(Pikafish) Web 集成与 URL 自动转换

### DIFF
--- a/src/lib/Movelist/Toolbar.svelte
+++ b/src/lib/Movelist/Toolbar.svelte
@@ -25,6 +25,7 @@
     { title: "回退", icon: "arrow-left", event: "undo" },
     { title: "前进", icon: "arrow-right", event: "redo" },
     { title: "终局", icon: "arrow-right-to-line", event: "toEnd" },
+    { title: "皮卡鱼Web", icon: "external-link", event: "openPikafish" },
   ];
 
   let saveBtnEl: HTMLButtonElement;

--- a/src/modules/GenFEN/Actions.ts
+++ b/src/modules/GenFEN/Actions.ts
@@ -1,6 +1,7 @@
 import { MarkdownView, Notice } from "obsidian";
 import { registerGenFENModule } from "../../core/module-system";
 import type { IBoard, IGenFENHost, ITurn } from "../../types";
+import { genFENFromBoard } from "../../utils/parse";
 
 export class ActionsModule {
     static init(host: IGenFENHost) {
@@ -79,28 +80,4 @@ async function onSaveBTNClick(host: IGenFENHost) {
         return newContent;
     });
     new Notice("FEN已保存到代码块");
-}
-function genFENFromBoard(board: IBoard, turn: ITurn): string {
-    // board[x][y]，x为列，y为行
-    const rows: string[] = [];
-    for (let y = 0; y < 10; y++) {
-        let fenRow = "";
-        let empty = 0;
-        for (let x = 0; x < 9; x++) {
-            const cell = board[x][y];
-            if (!cell) {
-                empty++;
-            } else {
-                if (empty > 0) {
-                    fenRow += empty;
-                    empty = 0;
-                }
-                fenRow += cell;
-            }
-        }
-        if (empty > 0) fenRow += empty;
-        rows.push(fenRow);
-    }
-    const fen = rows.join("/");
-    return `${fen} ${turn === "red" ? "w" : "b"}`;
 }

--- a/src/modules/MoveList/Actions.ts
+++ b/src/modules/MoveList/Actions.ts
@@ -1,7 +1,7 @@
 import { MarkdownView, Notice } from "obsidian";
 import { registerXQModule } from "../../core/module-system";
 import type { IMove, IXQHost, PieceType } from "../../types";
-import { getICCS } from "../../utils/parse";
+import { getICCS, genFENFromBoard, parseSource } from "../../utils/parse";
 import { ConfirmModal } from "../../utils/confirmModal";
 
 export class ActionsModule {
@@ -104,6 +104,22 @@ export class ActionsModule {
                 }
             }
             eventBus.emit('updateUI');
+        })
+
+        eventBus.on('openPikafish', () => {
+            // 1. 获取初始局面
+            const { board, firstTurn } = parseSource(host.source);
+            const fen = genFENFromBoard(board, firstTurn);
+
+            // 2. 获取移动记录
+            const moves = host.modified ? host.history : host.PGN;
+
+            // 3. 转换为 UCI 格式字符串
+            const movesStr = moves.map(m => m.ICCS?.replace('-', '').toLowerCase()).join('');
+
+            // 4. 生成 URL
+            const url = `https://xiangqiai.com/#/${fen} moves ${movesStr}`;
+            window.open(url);
         })
     }
 }

--- a/src/modules/Source.ts
+++ b/src/modules/Source.ts
@@ -1,5 +1,6 @@
 import { registerGenFENModule, registerXQModule } from "../core/module-system";
-import { parseSource } from "../utils/parse";
+import { parseSource, genFENFromBoard } from "../utils/parse";
+import { MarkdownView } from "obsidian";
 
 export const SourceModule = {
 
@@ -8,13 +9,51 @@ export const SourceModule = {
 		eventBus.on('load', (renderChild: string) => {
 			switch (renderChild) {
 				case 'xq':
-					const { haveFEN, board, PGN, firstTurn, options } = parseSource(host.source)
+					const { haveFEN, board, PGN, firstTurn, options, isPikafishUrl } = parseSource(host.source)
 					host.haveFEN = haveFEN;
 					host.board = board;
 					host.PGN = PGN;
 					host.currentTurn = firstTurn;
 					host.currentStep = 0;
 					host.options = options;
+
+					if (isPikafishUrl) {
+						// 自动转换为标准语法
+						const fen = genFENFromBoard(board, firstTurn);
+						
+						const pgnLines: string[] = [];
+						for (let i = 0; i < PGN.length; i += 2) {
+							const move1 = PGN[i].ICCS;
+							const move2 = PGN[i + 1]?.ICCS || "";
+							const line = `${Math.ceil((i + 1) / 2)}. ${move1} ${move2}`.trim();
+							pgnLines.push(line);
+						}
+						const moves = pgnLines.join("\n");
+						
+						const newContent = `${fen}\n${moves}`;
+
+						// 触发文件更新
+						const view = host.plugin.app.workspace.getActiveViewOfType(MarkdownView);
+						if (view && view.file) {
+							host.plugin.app.vault.process(view.file, (fileContent: string) => {
+								const section = host.ctx.getSectionInfo(host.containerEl);
+								if (!section) return fileContent;
+								const { lineStart, lineEnd } = section;
+								const lines = fileContent.split("\n");
+								const blockLines = lines.slice(lineStart, lineEnd + 1);
+								
+								// 替换代码块内容
+								// 保留首尾行 (```xiangqi 和 ```)
+								const newBlockLines = [blockLines[0], newContent, blockLines[blockLines.length - 1]];
+								
+								return [
+									...lines.slice(0, lineStart),
+									...newBlockLines,
+									...lines.slice(lineEnd + 1)
+								].join("\n");
+							});
+						}
+					}
 					break;
 				case 'fen':
 					host.board = parseSource('').board;

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,7 @@ export interface IXQHost extends IHost {
 	options?: IOptions;
 	haveFEN?: boolean;
 	Xiangqi?: SvelteComponent;
+	source: string;
 }
 
 export interface IGenFENHost extends IHost {


### PR DESCRIPTION
本 PR 新增了与皮卡鱼 Web (xiangqiai.com) 的集成，以增强插件的分析能力。

主要变更：
皮卡鱼 Web 按钮：在棋盘工具栏增加了一个按钮。点击该按钮可在皮卡鱼 Web 中打开当前棋盘局面进行分析。生成的 URL 包含 FEN 和走棋历史（转换为 UCI 格式），以提供完整的对局上下文。
URL 自动转换：实现了自动检测粘贴到 xiangqi 代码块中的皮卡鱼 Web URL（例如 https://xiangqiai.com/#/...）的逻辑。
标准语法转换：当检测到皮卡鱼 URL 时，插件会自动将代码块内容转换为插件支持的标准语法（FEN + 招法）。
招法格式化：转换后的招法会被格式化为易读的编号行格式（例如 1. A1-A2 B1-B2）。