### PR TITLE
针对mac和ios端的My changes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "id": "xiangqi",
-    "version": "2.5.26",
+    "version": "2.5.27",
     "name": "Chinese chess",
     "description": "A Chinese Chess (象棋/xiangqi) plugin designed for Obsidian",
     "author": "000100",

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
     "version": "2.5.26",
     "name": "Chinese chess",
     "description": "A Chinese Chess (象棋/xiangqi) plugin designed for Obsidian",
-    "author": "weshell",
-    "authorUrl": "https://space.bilibili.com/156446344",
+    "author": "000100",
+    "authorUrl": "",
     "minAppVersion": "1.5.0",
     "isDesktopOnly": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
     "version": "2.5.27",
     "name": "Chinese chess",
     "description": "A Chinese Chess (象棋/xiangqi) plugin designed for Obsidian",
-    "author": "000100",
-    "authorUrl": "",
+    "author": "weshell",
+    "authorUrl": "https://space.bilibili.com/156446344",
     "minAppVersion": "1.5.0",
     "isDesktopOnly": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -543,8 +543,7 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.53.5",
@@ -870,6 +869,7 @@
       "integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "debug": "^4.4.1",
@@ -951,6 +951,7 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1086,6 +1087,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1191,8 +1193,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1490,6 +1491,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1644,8 +1646,7 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/svelte": {
       "version": "5.46.0",
@@ -1653,6 +1654,7 @@
       "integrity": "sha512-ZhLtvroYxUxr+HQJfMZEDRsGsmU46x12RvAv/zi9584f5KOX7bUrEbhPJ7cKFmUvZTJXi/CFZUYwDC6M1FigPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1772,6 +1774,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1793,6 +1796,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -1983,8 +1987,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "svelte5",
     "typescript"
   ],
-  "author": "weshell",
+  "author": "000100",
+  "authorUrl": "",
   "license": "MIT",
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-xiangqi",
   "private": true,
-  "version": "2.5.26",
+  "version": "2.5.27",
   "description": "Render xiangqi(Chinese chess) positions diagrams in a note.",
   "main": "main.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "svelte5",
     "typescript"
   ],
-  "author": "000100",
-  "authorUrl": "",
+  "author": "weshell",
+  "authorUrl": "https://space.bilibili.com/156446344",
   "license": "MIT",
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.1",

--- a/src/lib/Board.svelte
+++ b/src/lib/Board.svelte
@@ -11,6 +11,7 @@
     currentTurn: string;
     eventBus: EventBus;
     rotated: boolean;
+    variations?: IMove[];
   }
 
   let {
@@ -21,6 +22,7 @@
     currentTurn,
     eventBus,
     rotated,
+    variations = [],
   }: Props = $props();
 
   let Bnum = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
@@ -65,6 +67,20 @@
   let renderedLastMove = $derived(
     rotated && lastMove ? { from: rotatePos(lastMove.from), to: rotatePos(lastMove.to) } : lastMove,
   );
+
+  // 着法颜色数组
+  const colors = [
+    'var(--interactive-accent)', // 主线路颜色
+    '#FF6B6B', // 分支1颜色
+    '#4ECDC4', // 分支2颜色
+    '#45B7D1', // 分支3颜色
+    '#96CEB4', // 分支4颜色
+    '#FFEAA7', // 分支5颜色
+    '#DDA0DD', // 分支6颜色
+    '#98D8C8', // 分支7颜色
+    '#F7DC6F', // 分支8颜色
+    '#BB8FCE'  // 分支9颜色
+  ];
 
   function handleClick(e: MouseEvent) {
     const svg = e.currentTarget as SVGSVGElement;
@@ -243,6 +259,68 @@
         {/each}
       {/each}
     </g>
+
+    <!-- 分支线路 -->
+    {#if variations && variations.length > 0}
+      <g id="variations">
+        {#each variations as variation, index}
+          <!-- 计算变着的起点和终点 -->
+          {#if variation.from && variation.to}
+            {@const from = rotated ? rotatePos(variation.from) : variation.from}
+            {@const to = rotated ? rotatePos(variation.to) : variation.to}
+            <!-- 计算起点和终点的坐标 -->
+            {@const fromX = (from.x + 1) * cellSize}
+            {@const fromY = (from.y + 1) * cellSize}
+            {@const toX = (to.x + 1) * cellSize}
+            {@const toY = (to.y + 1) * cellSize}
+            
+            <!-- 判断是否为主线路 -->
+            {@const isMainLine = index === 0}
+            <!-- 获取当前着法的颜色 -->
+            {@const color = colors[index % colors.length]}
+            
+            <!-- 绘制着法线路 -->
+            <line
+              x1={fromX}
+              y1={fromY}
+              x2={toX}
+              y2={toY}
+              stroke={color}
+              stroke-width={isMainLine ? cellSize * 0.06 : cellSize * 0.04}
+              stroke-dasharray={isMainLine ? 'none' : `${cellSize * 0.2} ${cellSize * 0.1}`}
+              opacity={isMainLine ? 0.8 : 0.7}
+              stroke-linecap="round"
+            />
+            <!-- 绘制着法终点标记 -->
+            <circle
+              cx={toX}
+              cy={toY}
+              r={isMainLine ? cellSize * 0.3 : cellSize * 0.25}
+              stroke={color}
+              stroke-width={isMainLine ? cellSize * 0.06 : cellSize * 0.04}
+              fill="none"
+              opacity={isMainLine ? 0.8 : 0.7}
+            />
+            
+            <!-- 为主线路添加文本标记 -->
+            {#if isMainLine}
+              <text
+                x={toX}
+                y={toY}
+                fill={color}
+                font-size={cellSize * 0.3}
+                text-anchor="middle"
+                dominant-baseline="middle"
+                opacity="0.8"
+                font-weight="bold"
+              >
+                主
+              </text>
+            {/if}
+          {/if}
+        {/each}
+      </g>
+    {/if}
 
     <!-- 单个位置标记 -->
     {#if renderedMarkedPos}

--- a/src/lib/Board.svelte
+++ b/src/lib/Board.svelte
@@ -45,7 +45,7 @@
     rotated && markedPos ? rotatePos(markedPos) : markedPos,
   );
 
-  let { cellSize, showLastMove, showTurnBorder, showCoordinateLabels } = $derived(settings);
+  let { cellSize, showLastMove, showTurnBorder, showCoordinateLabels, boardMarginTop, boardMarginBottom } = $derived(settings);
   let margin = $derived(cellSize * 0.1);
   let width = $derived(cellSize * 10);
   let height = $derived(cellSize * 11);
@@ -110,7 +110,7 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="board-container">
+<div class="board-container" style={`--board-margin-top: ${boardMarginTop}; --board-margin-bottom: ${boardMarginBottom};`}>
   <svg {width} {height} viewBox={`0 0 ${width} ${height}`} class="xq-board" onclick={handleClick}>
     <!-- 背景 -->
     <rect
@@ -382,6 +382,8 @@
     --piece-red: var(--xq-piece-red, var(--color-red));
     --piece-black: var(--xq-piece-black, var(--color-blue));
     --text-color: var(--xq-text-color, var(--text-normal));
+    margin-top: calc(var(--board-margin-top, 0px) * 1px);
+    margin-bottom: calc(var(--board-margin-bottom, 0px) * 1px);
   }
   .xq-board {
     user-select: none;

--- a/src/lib/Board.svelte
+++ b/src/lib/Board.svelte
@@ -68,18 +68,18 @@
     rotated && lastMove ? { from: rotatePos(lastMove.from), to: rotatePos(lastMove.to) } : lastMove,
   );
 
-  // 着法颜色数组
+  // 着法颜色数组 - 统一为橙色
   const colors = [
-    'var(--interactive-accent)', // 主线路颜色
-    '#FF6B6B', // 分支1颜色
-    '#4ECDC4', // 分支2颜色
-    '#45B7D1', // 分支3颜色
-    '#96CEB4', // 分支4颜色
-    '#FFEAA7', // 分支5颜色
-    '#DDA0DD', // 分支6颜色
-    '#98D8C8', // 分支7颜色
-    '#F7DC6F', // 分支8颜色
-    '#BB8FCE'  // 分支9颜色
+    'rgba(255, 102, 0, 0.8)', // 半透明橙色
+    'rgba(255, 102, 0, 0.8)', // 半透明橙色
+    'rgba(255, 102, 0, 0.8)', // 半透明橙色
+    'rgba(255, 102, 0, 0.8)', // 半透明橙色
+    'rgba(255, 102, 0, 0.8)', // 半透明橙色
+    'rgba(255, 102, 0, 0.8)', // 半透明橙色
+    'rgba(255, 102, 0, 0.8)', // 半透明橙色
+    'rgba(255, 102, 0, 0.8)', // 半透明橙色
+    'rgba(255, 102, 0, 0.8)', // 半透明橙色
+    'rgba(255, 102, 0, 0.8)'  // 半透明橙色
   ];
 
   function handleClick(e: MouseEvent) {
@@ -261,7 +261,7 @@
     </g>
 
     <!-- 分支线路 -->
-    {#if variations && variations.length > 0}
+    {#if variations && variations.length > 1}
       <g id="variations">
         {#each variations as variation, index}
           <!-- 计算变着的起点和终点 -->
@@ -286,37 +286,35 @@
               x2={toX}
               y2={toY}
               stroke={color}
-              stroke-width={isMainLine ? cellSize * 0.06 : cellSize * 0.04}
+              stroke-width={cellSize * 0.08}
               stroke-dasharray={isMainLine ? 'none' : `${cellSize * 0.2} ${cellSize * 0.1}`}
-              opacity={isMainLine ? 0.8 : 0.7}
+              opacity={0.7}
               stroke-linecap="round"
             />
             <!-- 绘制着法终点标记 -->
             <circle
               cx={toX}
               cy={toY}
-              r={isMainLine ? cellSize * 0.3 : cellSize * 0.25}
+              r={cellSize * 0.35}
               stroke={color}
-              stroke-width={isMainLine ? cellSize * 0.06 : cellSize * 0.04}
+              stroke-width={cellSize * 0.08}
               fill="none"
-              opacity={isMainLine ? 0.8 : 0.7}
+              opacity={0.7}
             />
             
-            <!-- 为主线路添加文本标记 -->
-            {#if isMainLine}
-              <text
-                x={toX}
-                y={toY}
-                fill={color}
-                font-size={cellSize * 0.3}
-                text-anchor="middle"
-                dominant-baseline="middle"
-                opacity="0.8"
-                font-weight="bold"
-              >
-                主
-              </text>
-            {/if}
+            <!-- 为着法添加数字标记 -->
+            <text
+              x={toX}
+              y={toY}
+              fill={color}
+              font-size={cellSize * 0.5}
+              text-anchor="middle"
+              dominant-baseline="middle"
+              opacity="0.9"
+              font-weight="bold"
+            >
+              {index + 1}
+            </text>
           {/if}
         {/each}
       </g>

--- a/src/lib/Movelist/Toolbar.svelte
+++ b/src/lib/Movelist/Toolbar.svelte
@@ -25,6 +25,7 @@
     { title: "回退", icon: "arrow-left", event: "undo" },
     { title: "前进", icon: "arrow-right", event: "redo" },
     { title: "终局", icon: "arrow-right-to-line", event: "toEnd" },
+    { title: "翻转", icon: "rotate-ccw", event: "rotate" },
     { title: "皮卡鱼Web", icon: "external-link", event: "openPikafish" },
   ];
 

--- a/src/lib/Tree/Toolbar.svelte
+++ b/src/lib/Tree/Toolbar.svelte
@@ -14,6 +14,7 @@
     { title: "回退", icon: "arrow-left", event: "back" },
     { title: "前进", icon: "arrow-right", event: "next" },
     { title: "终局", icon: "arrow-right-to-line", event: "toEnd" },
+    { title: "翻转", icon: "rotate-ccw", event: "rotate" },
     { title: "皮卡鱼Web", icon: "external-link", event: "openPikafish" },
     { title: "标注", icon: "tag", event: "toggle-annotation-menu" },
   ];
@@ -61,9 +62,11 @@
       onclick={(e) => {
         if (event === "toggle-annotation-menu") {
           handleAnnotationMenu(e); // ← 打开标注菜单
-        } else {
-          emitEvent(event);
-        }
+        } else if (event === "rotate") {
+    eventBus.emit("rotate");
+  } else {
+    emitEvent(event);
+  }
       }}
     ></button>
   {/each}

--- a/src/lib/Tree/Tree.svelte
+++ b/src/lib/Tree/Tree.svelte
@@ -314,11 +314,6 @@
             class="node-group"
             transform="translate({node.x! * spacingX} {node.y! * spacingY})"
             opacity={currentPath.includes(node.id) ? 1 : 0.8}
-            filter={!currentPath.includes(node.id)
-              ? "grayscale(100%) brightness(0.75)"
-              : node.id === currentNode?.id
-                ? "brightness(1.5) saturate(1.4) drop-shadow(0 0 1px rgba(255, 255, 255, 0.6))"
-                : undefined}
             stroke-width={node.id === currentNode?.id ? height * 0.09 : height * 0.045}
             onclick={() => eventBus.emit("node-click", node.id)}
           >
@@ -342,11 +337,13 @@
                 {height}
                 rx="2.5"
                 ry="2.5"
-                fill={node.side === "red"
-                  ? "var(--piece-red)"
-                  : node.side === "black"
-                    ? "var(--piece-black)"
-                    : "gray"}
+                fill={currentPath.includes(node.id) || !node.data
+                  ? (node.side === "red"
+                    ? "var(--piece-red)"
+                    : node.side === "black"
+                      ? "var(--piece-black)"
+                      : "green")
+                  : "gray"}
                 stroke={node.id === currentNode?.id ? "green" : "var(--board-line)"}
                 stroke-width={node.id === currentNode?.id ? height * 0.18 : height * 0.09}
               />

--- a/src/lib/Tree/Tree.svelte
+++ b/src/lib/Tree/Tree.svelte
@@ -385,7 +385,7 @@
     bind:this={textareaEl}
     oninput={handleCommentsInput}
     onblur={handleCommentsBlur}
-    rows="1"
+    rows="10"
   ></textarea>
 </div>
 
@@ -446,8 +446,8 @@
 
   textarea {
     width: 100%;
-    height: var(--textarea-height, 20px);
-    max-height: 80px;
+    height: var(--textarea-height, 200px);
+    max-height: 300px;
     resize: none;
     font-family: var(--font-family);
     font-size: var(--font-size-normal);
@@ -455,7 +455,7 @@
     background: var(--background-secondary);
     border: 1px solid var(--background-modifier-border);
     border-radius: 3px;
-    padding: 0;
+    padding: 4px 8px;
     outline: none;
     overflow-y: auto;
   }

--- a/src/lib/Tree/Tree.svelte
+++ b/src/lib/Tree/Tree.svelte
@@ -346,7 +346,8 @@
                   : node.side === "black"
                     ? "var(--piece-black)"
                     : "gray"}
-                stroke="var(--board-line)"
+                stroke={node.id === currentNode?.id ? "green" : "var(--board-line)"}
+                stroke-width={node.id === currentNode?.id ? "2" : "1"}
               />
               <text dy="3.5" text-anchor="middle" fill="white" font-size="9px">
                 {node.data?.type ? PIECE_CHARS[node.data.type] : "始"}

--- a/src/lib/Tree/Tree.svelte
+++ b/src/lib/Tree/Tree.svelte
@@ -11,9 +11,10 @@
     eventBus: EventBus;
     currentNode: ChessNode | null;
     currentPath: string[];
+    settings: any;
   }
 
-  let { nodeMap, eventBus, currentNode = $bindable(), currentPath }: Props = $props();
+  let { nodeMap, eventBus, currentNode = $bindable(), currentPath, settings }: Props = $props();
 
   // ---- 状态 ----
   let commentsText = $state("");
@@ -65,10 +66,10 @@
   }
 
   // ---- 常量 ----
-  const spacingX = 22;
-  const spacingY = 15;
-  const width = 13;
-  const height = 11;
+  let spacingX = $derived((settings?.cellSize || 50) * 0.44); // 基于cellSize计算，保持比例
+  let spacingY = $derived((settings?.cellSize || 50) * 0.3); // 基于cellSize计算，保持比例
+  let width = $derived((settings?.cellSize || 50) * 0.26); // 基于cellSize计算，保持比例
+  let height = $derived((settings?.cellSize || 50) * 0.22); // 基于cellSize计算，保持比例
   const lucide_message_square_text = `<path d="M22 17a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 21.286V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z"/><path d="M7 11h10"/><path d="M7 15h6"/><path d="M7 7h8"/>`;
   const lucide_smile = `<path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/>`;
   const lucide_thumbs_up = `<path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/><path d="M7 10v12"/>`;
@@ -168,7 +169,7 @@
       },
       minZoom: 0.5,
       maxZoom: 4,
-      zoomSpeed: 0.2,
+      zoomSpeed: 0.02,
     });
 
     handleEvent = handlers.handleEvent;
@@ -318,16 +319,16 @@
               : node.id === currentNode?.id
                 ? "brightness(1.5) saturate(1.4) drop-shadow(0 0 1px rgba(255, 255, 255, 0.6))"
                 : undefined}
-            stroke-width={node.id === currentNode?.id ? 1 : 0.5}
+            stroke-width={node.id === currentNode?.id ? height * 0.09 : height * 0.045}
             onclick={() => eventBus.emit("node-click", node.id)}
           >
             {#if primaryAnnotation}
               {@const def = ANNOTATION_DEFINITIONS[primaryAnnotation]}
               <g
-                transform="translate({-7.2} {-7.2}) scale(0.6)"
+                transform={`scale(${height * 0.06}) translate(-12 -12)`}
                 fill={def.color}
                 stroke="currentColor"
-                stroke-width="1.5"
+                stroke-width={height * 0.15}
                 stroke-linecap="round"
                 stroke-linejoin="round"
               >
@@ -347,9 +348,9 @@
                     ? "var(--piece-black)"
                     : "gray"}
                 stroke={node.id === currentNode?.id ? "green" : "var(--board-line)"}
-                stroke-width={node.id === currentNode?.id ? "2" : "1"}
+                stroke-width={node.id === currentNode?.id ? height * 0.18 : height * 0.09}
               />
-              <text dy="3.5" text-anchor="middle" fill="white" font-size="9px">
+              <text dy={height * 0.32} text-anchor="middle" fill="white" font-size={height * 0.8}>
                 {node.data?.type ? PIECE_CHARS[node.data.type] : "始"}
               </text>
             {/if}
@@ -357,10 +358,10 @@
             <!-- 评论标记 -->
             {#if getRegularComments(node).length > 0}
               <g
-                transform="translate({0.35 * width} {-0.7 * height}) scale(0.35)"
+                transform={`translate(${0.35 * width} ${-0.7 * height}) scale(${height * 0.035})`}
                 fill="royalblue"
                 stroke="currentColor"
-                stroke-width="1.5"
+                stroke-width={height * 0.15}
                 stroke-linecap="round"
                 stroke-linejoin="round"
               >

--- a/src/lib/Tree/Xiangqi.svelte
+++ b/src/lib/Tree/Xiangqi.svelte
@@ -50,10 +50,10 @@
 </script>
 
 <div class="tree-view {position}">
-  <Board {settings} {board} {lastMove} {markedPos} {currentTurn} {eventBus} {rotated} {variations} />
-  <Toolbar {eventBus} />
-  <Tree {nodeMap} {eventBus} {currentNode} {currentPath} />
-</div>
+    <Board {settings} {board} {lastMove} {markedPos} {currentTurn} {eventBus} {rotated} {variations} />
+    <Toolbar {eventBus} />
+    <Tree {nodeMap} {eventBus} {currentNode} {currentPath} {settings} />
+  </div>
 
 <style>
   :global(.view-content.pgn-view) {
@@ -73,10 +73,29 @@
     gap: 2px;
   }
 
+  .tree-view.right :global(.tree-container) {
+    flex: 1 1 auto;
+    min-width: 300px;
+  }
+
+  .tree-view.right :global(.svg-wrapper) {
+    min-width: 280px;
+  }
+
   .tree-view.bottom {
     flex-direction: column;
     align-items: center;
     height: 100%;
-    max-width: 40vh;
+  }
+
+  .tree-view.bottom :global(.tree-container) {
+    flex: 1 1 auto;
+    min-width: 400px;
+    width: 100%;
+  }
+
+  .tree-view.bottom :global(.svg-wrapper) {
+    min-width: 380px;
+    width: 100%;
   }
 </style>

--- a/src/lib/Tree/Xiangqi.svelte
+++ b/src/lib/Tree/Xiangqi.svelte
@@ -31,6 +31,11 @@
   let lastMove = $derived(currentNode.data);
   let position = $derived(settings.position);
   let rotated = $state(false);
+  let variations = $derived(
+    currentNode.children
+      .map(child => child.data)
+      .filter((data): data is IMove => data !== null) // 过滤掉null值
+  );
 
   onMount(async () => {
     await tick();
@@ -45,7 +50,7 @@
 </script>
 
 <div class="tree-view {position}">
-  <Board {settings} {board} {lastMove} {markedPos} {currentTurn} {eventBus} {rotated} />
+  <Board {settings} {board} {lastMove} {markedPos} {currentTurn} {eventBus} {rotated} {variations} />
   <Toolbar {eventBus} />
   <Tree {nodeMap} {eventBus} {currentNode} {currentPath} />
 </div>

--- a/src/lib/Tree/Xiangqi.svelte
+++ b/src/lib/Tree/Xiangqi.svelte
@@ -30,15 +30,22 @@
 
   let lastMove = $derived(currentNode.data);
   let position = $derived(settings.position);
+  let rotated = $state(false);
 
   onMount(async () => {
     await tick();
     eventBus.emit("ready");
   });
+
+  $effect(() => {
+    eventBus.on('rotate', () => {
+      rotated = !rotated;
+    });
+  });
 </script>
 
 <div class="tree-view {position}">
-  <Board {settings} {board} {lastMove} {markedPos} {currentTurn} {eventBus} rotated={false} />
+  <Board {settings} {board} {lastMove} {markedPos} {currentTurn} {eventBus} {rotated} />
   <Toolbar {eventBus} />
   <Tree {nodeMap} {eventBus} {currentNode} {currentPath} />
 </div>

--- a/src/lib/Tree/interact.ts
+++ b/src/lib/Tree/interact.ts
@@ -21,6 +21,9 @@ export function createInteractionHandlers(
     let startY = 0;
 
     let lastTouchDistance = 0;
+    
+    // 点击阈值，用于区分点击和拖动
+    const CLICK_THRESHOLD = 5;
 
     function getTouchDistance(touches: TouchList): number {
         if (touches.length < 2) return 0;
@@ -88,7 +91,8 @@ export function createInteractionHandlers(
             case "touchstart": {
                 const event = e as TouchEvent;
                 if (event.touches.length === 1) {
-                    isDragging = true;
+                    // 初始设置为false，只有在移动超过阈值后才设为true
+                    isDragging = false;
                     dragStartX = event.touches[0].clientX;
                     dragStartY = event.touches[0].clientY;
                     startX = state.x;
@@ -102,17 +106,24 @@ export function createInteractionHandlers(
 
             case "touchmove": {
                 const event = e as TouchEvent;
-                event.preventDefault();
-
-                if (event.touches.length === 1 && isDragging) {
+                
+                if (event.touches.length === 1) {
                     const dx = event.touches[0].clientX - dragStartX;
                     const dy = event.touches[0].clientY - dragStartY;
-                    options.setState({
-                        x: startX + dx,
-                        y: startY + dy,
-                        scale: state.scale,
-                    });
+                    const distance = Math.hypot(dx, dy);
+                    
+                    // 如果移动距离超过阈值，才认为是拖动
+                    if (distance > CLICK_THRESHOLD) {
+                        isDragging = true;
+                        event.preventDefault();
+                        options.setState({
+                            x: startX + dx,
+                            y: startY + dy,
+                            scale: state.scale,
+                        });
+                    }
                 } else if (event.touches.length === 2) {
+                    event.preventDefault();
                     const newDistance = getTouchDistance(event.touches);
                     const delta = newDistance - lastTouchDistance;
                     if (Math.abs(delta) > 1) {

--- a/src/lib/Tree/interact.ts
+++ b/src/lib/Tree/interact.ts
@@ -12,7 +12,7 @@ export function createInteractionHandlers(
 ) {
     const minZoom = options.minZoom ?? 0.5;
     const maxZoom = options.maxZoom ?? 4;
-    const zoomSpeed = options.zoomSpeed ?? 0.2;
+    const zoomSpeed = options.zoomSpeed ?? 0.001;
 
     let isDragging = false;
     let dragStartX = 0;

--- a/src/modules/MoveList/Actions.ts
+++ b/src/modules/MoveList/Actions.ts
@@ -121,6 +121,16 @@ const ActionsModule = {
             const url = `https://xiangqiai.com/#/${fen} moves ${movesStr}`;
             window.open(url);
         })
+
+        eventBus.on('rotate', () => {
+            // 切换棋盘翻转状态
+            if (!host.options) {
+                host.options = { rotated: true };
+            } else {
+                host.options.rotated = !host.options.rotated;
+            }
+            eventBus.emit('updateUI', 'rotate');
+        })
     }
 }
 

--- a/src/modules/Tree/Tokenizer.ts
+++ b/src/modules/Tree/Tokenizer.ts
@@ -108,8 +108,16 @@ export function tokenize(pgn: string): Token[] {
             continue;
         }
 
-        // 其他无法识别的字符 → 报错
-        throw new Error(`无法识别的字符 '${char}' 在行 ${startLine}, 列 ${startCol}`);
+        // 尝试识别FEN字符串
+        const fen = matchAndConsume(/^[rnbakcpRNBAKCP1-9]+(\/[rnbakcpRNBAKCP1-9]+){8}(\s+[wb])?/);
+        if (fen) {
+            // 将FEN转换为标签格式
+            tokens.push({ type: "tag", value: `[FEN "${fen}"]`, line: startLine, column: startCol });
+            continue;
+        }
+
+        // 其他无法识别的字符 → 跳过（不再抛出错误）
+        advance(1);
     }
 
     tokens.push({ type: "eof", value: "", line, column });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,8 @@ export const DEFAULT_SETTINGS: ISettings = {
 	enableSpeech: true,
 	showMovelist: true,
 	showMovelistText: true,
+	boardMarginTop: 20,
+	boardMarginBottom: 20,
 	viewOnly: false,
 	rotated: false,
 };
@@ -193,6 +195,60 @@ export class XQSettingTab extends PluginSettingTab {
 						settings.autoJump = value as "never" | "always" | "auto";
 						this.plugin.saveSettings();
 					});
+			});
+
+		new Setting(containerEl).setName("棋盘边距").setHeading();
+
+		new Setting(containerEl)
+			.setName("上边距")
+			.setDesc("调整棋盘顶部边距")
+			.addSlider((slider) => {
+				const controlEl = slider.sliderEl.parentElement!;
+				const valueLabel = createEl("span", {
+					text: Math.abs(settings.boardMarginTop).toString(),
+					cls: "slider-value-label",
+				});
+				controlEl.prepend(valueLabel);
+				slider
+					.setLimits(0, 100, 1)
+					.setValue(settings.boardMarginTop)
+					.onChange((value) => {
+						settings.boardMarginTop = value;
+						valueLabel.textContent = value.toString();
+						this.plugin.saveSettings();
+						this.plugin.refresh();
+					});
+				slider.sliderEl.addEventListener("input", () => {
+					const value = slider.getValue();
+					settings.boardMarginTop = value;
+					valueLabel.textContent = value.toString();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName("下边距")
+			.setDesc("调整棋盘底部边距")
+			.addSlider((slider) => {
+				const controlEl = slider.sliderEl.parentElement!;
+				const valueLabel = createEl("span", {
+					text: Math.abs(settings.boardMarginBottom).toString(),
+					cls: "slider-value-label",
+				});
+				controlEl.prepend(valueLabel);
+				slider
+					.setLimits(0, 100, 1)
+					.setValue(settings.boardMarginBottom)
+					.onChange((value) => {
+						settings.boardMarginBottom = value;
+						valueLabel.textContent = value.toString();
+						this.plugin.saveSettings();
+						this.plugin.refresh();
+					});
+				slider.sliderEl.addEventListener("input", () => {
+					const value = slider.getValue();
+					settings.boardMarginBottom = value;
+					valueLabel.textContent = value.toString();
+				});
 			});
 
 		if (window.speechSynthesis) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface ISettings {
 	enableSpeech: boolean;
 	showMovelist: boolean;
 	showMovelistText: boolean;
+	boardMarginTop: number;
+	boardMarginBottom: number;
 	viewOnly?: boolean;
 	rotated?: boolean;
 }


### PR DESCRIPTION
主要针对mac和ios做了一些优化，我是用ai辅助修改的，应该是针对pgn模式做了修改。现在我用了一段时间，感觉没有问题。请参考。

## 新增功能
- **增加了3种模式下的棋盘翻转**
- **棋盘边距控制**：【原来版本在ios端的棋盘会被ob的标题和工具栏遮挡住】
  - 在 `src/settings.ts` 中添加了 `boardMarginTop` 和 `boardMarginBottom` 设置项（默认值均为 20）
  - 在设置界面中添加了对应的滑块控件，支持实时调整棋盘的顶部和底部边距
  - 在 `src/lib/Board.svelte` 中实现了边距的实时绑定和应用
- **分叉树的颜色显示**
	- 当前分支是用彩色的，其他分支用灰色的，这样更醒目。
	- 当前步骤的棋子是绿色边框，起始的“始”也改成绿色了
- **pgn的棋盘上也显示了分支路径**
## 小修复
- xiangqi和xq代码保存之后在mac和ios上无法打开的问题，也做了修复。
- 分支图的宽度做了自适应
- 注释框的高度做了调整
## 修复的问题

### 1. 设置不生效问题
- **原因**：CSS 绑定语法错误，使用了无效的 `v-bind('settings.boardMarginTop')` 语法
- **修复**：改用 CSS 变量和内联样式绑定，确保边距设置实时生效
- **影响文件**：`src/lib/Board.svelte`

### 2. 分叉树显示问题
- **文本大小不一致**：
  - **原因**：文本大小硬编码为 `9px`，与布局大小无关
  - **修复**：使用动态值 `font-size={height * 0.8}`，确保文本大小随布局调整
- **旗标图标对齐**：
  - **原因**：变换顺序错误（先平移后缩放）
  - **修复**：调整变换顺序为 `transform={`scale(${height * 0.06}) translate(-12 -12)`}`，确保旗标居中显示
- **颜色显示**：
  - **原因**：移动端浏览器对 CSS `filter` 属性支持不完善
  - **修复**：改用颜色判断替代 CSS 滤镜，确保移动端非当前分支显示为灰色
  - **优化**：初始节点 "始" 始终显示为绿色（与当前棋子边框颜色一致），所有旗标始终保持彩色
- **影响文件**：`src/lib/Tree/Tree.svelte`

### 3. 交互体验问题
- **缩放灵敏度**：
  - **原因**：`zoomSpeed=0.2` 导致缩放速度过快，容易过度缩放
  - **修复**：将 `zoomSpeed` 调整为 `0.02`，提供更精确的缩放控制
- **触摸事件**：
  - **原因**：触摸事件立即触发拖动，阻止了节点点击
  - **修复**：添加 `CLICK_THRESHOLD = 5`，区分点击和拖动事件，确保节点点击正常触发
- **影响文件**：`src/lib/Tree/interact.ts`

### 4. 响应式设计问题
- **原因**：分叉树节点间距、大小等硬编码，与布局大小设置无关
- **修复**：使用 `$derived` 从 `settings.cellSize` 派生节点大小和间距，确保整体布局响应式调整
- **影响文件**：`src/lib/Tree/Tree.svelte`、`src/lib/Tree/Xiangqi.svelte`

